### PR TITLE
ジョブのgive upは別で補足できるので、ジョブが死んだ時はWARN

### DIFF
--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -280,7 +280,7 @@ module Resque
 
     # Reports the exception and marks the job as failed
     def report_failed_job(job,exception)
-      log_with_severity :error, "#{job.inspect} failed: #{exception.inspect}"
+      log_with_severity :warn, "#{job.inspect} failed: #{exception.inspect}"
       begin
         job.fail(exception)
       rescue Object => exception


### PR DESCRIPTION
* ログレベルで通知を分けているので、リトライ中のジョブの死亡はWARNにしたい
* 別でresque-retryでリトライが全部失敗した時にERROR出すので、resque側のジョブが死んだときのログはWARN